### PR TITLE
add config unavailable fallback

### DIFF
--- a/src/Bundle/DependencyInjection/SourceabilityInstrumentationExtension.php
+++ b/src/Bundle/DependencyInjection/SourceabilityInstrumentationExtension.php
@@ -16,27 +16,27 @@ class SourceabilityInstrumentationExtension extends ConfigurableExtension
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');
 
-        if ($config['listeners']['command']['enabled']) {
+        if ($config['listeners']['command']['enabled'] ?? false) {
             $loader->load('listener_command.yaml');
         }
 
-        if ($config['listeners']['messenger']['enabled']) {
+        if ($config['listeners']['messenger']['enabled'] ?? false) {
             $loader->load('listener_messenger.yaml');
         }
 
-        if ($config['profilers']['datadog']['enabled']) {
+        if ($config['profilers']['datadog']['enabled'] ?? false) {
             $loader->load('profiler_datadog.yaml');
         }
 
-        if ($config['profilers']['newrelic']['enabled']) {
+        if ($config['profilers']['newrelic']['enabled'] ?? false) {
             $loader->load('profiler_newrelic.yaml');
         }
 
-        if ($config['profilers']['symfony']['enabled']) {
+        if ($config['profilers']['symfony']['enabled'] ?? false) {
             $loader->load('profiler_symfony.yaml');
         }
 
-        if ($config['profilers']['tideways']['enabled']) {
+        if ($config['profilers']['tideways']['enabled'] ?? false) {
             $loader->load('profiler_tideways.yaml');
         }
 


### PR DESCRIPTION
If the requested config isn't available an undefined index exception is thrown. This bug is fixed with this commit.
