### PR TITLE
Unwrap Messenger HandlerFailedException

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
   "require-dev": {
     "datadog/dd-trace": "^0.60.0",
     "ekino/newrelic-bundle": "^2.2",
+    "jangregor/phpstan-prophecy": "^0.8.1",
+    "phpspec/prophecy-phpunit": "^2.0",
     "phpstan/phpstan": "^0.12.85",
     "phpstan/phpstan-deprecation-rules": "^0.12.6",
     "phpstan/phpstan-strict-rules": "^0.12.9",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,3 +19,4 @@ includes:
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - vendor/jangregor/phpstan-prophecy/extension.neon

--- a/src/Messenger/ProfilerMiddleware.php
+++ b/src/Messenger/ProfilerMiddleware.php
@@ -43,7 +43,10 @@ class ProfilerMiddleware implements MiddlewareInterface
                 ->handle($envelope, $stack)
             ;
         } catch (HandlerFailedException $exception) {
-            $this->profiler->stop($exception);
+            $nestedExceptions = $exception->getNestedExceptions();
+            $firstNestedException = reset($nestedExceptions);
+
+            $this->profiler->stop(false !== $firstNestedException ? $firstNestedException : $exception);
 
             throw $exception;
         } finally {

--- a/tests/EventListener/MessengerProfilerListenerTest.php
+++ b/tests/EventListener/MessengerProfilerListenerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sourceability\Instrumentation\Test\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sourceability\Instrumentation\EventListener\MessengerProfilerListener;
+use Sourceability\Instrumentation\Profiler\ProfilerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+
+/**
+ * @covers \MessengerProfilerListener
+ *
+ * @internal
+ */
+final class MessengerProfilerListenerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testOnReject(): void
+    {
+        $profiler = $this->prophesize(ProfilerInterface::class);
+
+        $listener = new MessengerProfilerListener($profiler->reveal());
+
+        $error = new \Exception('not good');
+
+        $profiler->stop($error)
+            ->shouldBeCalled()
+        ;
+
+        $event = new WorkerMessageFailedEvent(new Envelope(new \StdClass()), 'receiver', $error);
+        $listener->onReject($event);
+    }
+
+    public function testOnRejectUnwrapsHandlerFailedException(): void
+    {
+        $profiler = $this->prophesize(ProfilerInterface::class);
+
+        $listener = new MessengerProfilerListener($profiler->reveal());
+
+        $envelope = new Envelope(new \StdClass());
+
+        $error = new HandlerFailedException($envelope, [$handlerError = new \Exception('not good')]);
+
+        $profiler->stop($handlerError)
+            ->shouldBeCalled()
+        ;
+
+        $event = new WorkerMessageFailedEvent($envelope, 'receiver', $error);
+        $listener->onReject($event);
+    }
+}


### PR DESCRIPTION
Messenger wraps any exception that happens in a handler with `HandlerFailedException`.
This is even worse, because the actual exception is not set as `Exception::getPrevious()`.
So the only valuable information from the initial exception that makes its way to the profiler, is the message. No stack trace ... 😱 

This fixes that issue!