### PR TITLE
Update messenger profiler listener priority to wrap other subscribers

### DIFF
--- a/src/EventListener/MessengerProfilerListener.php
+++ b/src/EventListener/MessengerProfilerListener.php
@@ -24,10 +24,10 @@ class MessengerProfilerListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            WorkerMessageReceivedEvent::class => 'onInvoke',
-            WorkerMessageHandledEvent::class => 'onAcknowledge',
-            WorkerMessageFailedEvent::class => 'onReject',
-            WorkerStartedEvent::class => 'onPing',
+            WorkerMessageReceivedEvent::class => [['onInvoke', 2048]],
+            WorkerMessageHandledEvent::class => [['onAcknowledge', -2048]],
+            WorkerMessageFailedEvent::class => [['onReject', -2048]],
+            WorkerStartedEvent::class => [['onPing', -2048]],
         ];
     }
 


### PR DESCRIPTION
Hi,

This PR update the priority of the messenger profiler listener to make sure that the profiler is start before any other listener and is stop after any other listeners.