### PR TITLE
Remove DDTrace\Bootstap dependency as it is removed in dd 0.70.0+

### DIFF
--- a/src/Profiler/DatadogProfiler.php
+++ b/src/Profiler/DatadogProfiler.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Sourceability\Instrumentation\Profiler;
 
 use function dd_trace_env_config;
-use DDTrace\Bootstrap;
 use DDTrace\Contracts\Scope;
 use DDTrace\GlobalTracer;
 use DDTrace\Tag;
+use DDTrace\Tracer;
 use DDTrace\Type;
 use function ddtrace_config_app_name;
 use function ddtrace_config_trace_enabled;
@@ -86,7 +86,7 @@ class DatadogProfiler implements ProfilerInterface
             return;
         }
 
-        Bootstrap::resetTracer();
+        GlobalTracer::set(new Tracer());
     }
 
     private function isEnabled(): bool


### PR DESCRIPTION
`DDTrace\Bootstap` was removed in dd 0.70.0+ by https://github.com/DataDog/dd-trace-php/pull/1471.