### PR TITLE
Fix support for symfony 4.4 in SymfonyProfiler

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,12 @@ parameters:
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::#'
         - '#[Ff]unction (dd_?trace|DDTrace\\)\S+ (is )?not found#'
         - '#Call to static method [^(]+\(\) on an unknown class Tideways\\Profiler.#'
+        - message: '#Call to function method_exists\(\) with Symfony\\Component\\HttpFoundation\\RequestStack and .getMainRequest. will always evaluate to true#'
+          reportUnmatched: false
+        - message: '#Call to an undefined method Symfony\\Component\\HttpFoundation\\RequestStack::getMasterRequest\(\).#'
+          reportUnmatched: false
+        - message: '#Call to deprecated method getMasterRequest\(\) of class Symfony\\Component\\HttpFoundation\\RequestStack#'
+          reportUnmatched: false
 
         # See https://github.com/phpstan/phpstan-deprecation-rules/issues/76#issuecomment-1319808544
         - '#^Call to deprecated method prophesize\(\) of class Sourceability\\Instrumentation\\Test\\#'

--- a/src/Messenger/ProfilerMiddleware.php
+++ b/src/Messenger/ProfilerMiddleware.php
@@ -32,7 +32,10 @@ class ProfilerMiddleware implements MiddlewareInterface
 
         $skip = false;
         if (null !== $this->requestStack
-            && null !== $this->requestStack->getMainRequest()
+            && null !== (method_exists(
+                $this->requestStack,
+                'getMainRequest'
+            ) ? $this->requestStack->getMainRequest() : $this->requestStack->getMasterRequest())
         ) {
             $skip = true;
         }

--- a/src/Profiler/SymfonyProfiler.php
+++ b/src/Profiler/SymfonyProfiler.php
@@ -74,7 +74,10 @@ class SymfonyProfiler implements ProfilerInterface
 
         $requestStackToCleanUp = null;
         if (null !== $this->requestStack
-            && null === $this->requestStack->getMainRequest()
+            && null === (method_exists(
+                $this->requestStack,
+                'getMainRequest'
+            ) ? $this->requestStack->getMainRequest() : $this->requestStack->getMasterRequest())
         ) {
             // Fixes: Notice: Trying to get property 'attributes' of non-object
             // See https://github.com/symfony/symfony/blob/e34cd7dd2c6d0b30d24cad443b8f964daa841d71/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php#L109


### PR DESCRIPTION
Symfony 4.4 uses the older method `getMasterRequest()` instead of `getMainRequest()`.   Since 4.4 is supported by this library at this time, I propose this change so it correctly works using symfony 4.4.