### PR TITLE
Respect Datadog DD_TRACE_SAMPLE_RATE rate limiting environment variable

### DIFF
--- a/src/Profiler/DatadogProfiler.php
+++ b/src/Profiler/DatadogProfiler.php
@@ -21,15 +21,28 @@ class DatadogProfiler implements ProfilerInterface
     private ?Scope $scope = null;
 
     private LoggerInterface $logger;
+    private ?float $sampleRate;
 
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
+
+        $sampleRateString = getenv('DD_TRACE_SAMPLE_RATE');
+        if(is_numeric($sampleRateString)) {
+            $sampleRate = floatval($sampleRateString);
+            $this->sampleRate = $sampleRate;
+        } else {
+            $this->sampleRate = null;
+        }
     }
 
     public function start(string $name, ?string $kind = null): void
     {
         if (!$this->isEnabled()) {
+            return;
+        }
+
+        if($this->rateLimited()) {
             return;
         }
 
@@ -87,6 +100,15 @@ class DatadogProfiler implements ProfilerInterface
         }
 
         GlobalTracer::set(new Tracer());
+    }
+
+    private function rateLimited(): bool
+    {
+        if($this->sampleRate) {
+            $randomFloat = mt_rand() / mt_getrandmax(); // between 0 and 1
+            return $randomFloat > $this->sampleRate;
+        }  
+        return false;
     }
 
     private function isEnabled(): bool

--- a/src/Profiler/DatadogProfiler.php
+++ b/src/Profiler/DatadogProfiler.php
@@ -21,7 +21,8 @@ class DatadogProfiler implements ProfilerInterface
     private ?Scope $scope = null;
 
     private LoggerInterface $logger;
-    private ?float $sampleRate;
+
+    private float $sampleRate = 1.0;
 
     public function __construct(LoggerInterface $logger)
     {
@@ -31,8 +32,6 @@ class DatadogProfiler implements ProfilerInterface
         if(is_numeric($sampleRateString)) {
             $sampleRate = floatval($sampleRateString);
             $this->sampleRate = $sampleRate;
-        } else {
-            $this->sampleRate = null;
         }
     }
 
@@ -104,11 +103,8 @@ class DatadogProfiler implements ProfilerInterface
 
     private function rateLimited(): bool
     {
-        if($this->sampleRate) {
-            $randomFloat = mt_rand() / mt_getrandmax(); // between 0 and 1
-            return $randomFloat > $this->sampleRate;
-        }  
-        return false;
+        $randomFloat = mt_rand() / mt_getrandmax(); // between 0 and 1
+        return $randomFloat > $this->sampleRate;
     }
 
     private function isEnabled(): bool


### PR DESCRIPTION
Currently the instrumentation wraps all requests and does not respect the DD_TRACE_SAMPLE_RATE environment variable.  This patch allows it to respect the environment variable sample only at the desired rate.