### PR TITLE
Remove manual rate limiting  and fix GlobalTracer reset

### DIFF
--- a/src/Profiler/DatadogProfiler.php
+++ b/src/Profiler/DatadogProfiler.php
@@ -8,6 +8,7 @@ use function dd_trace_env_config;
 use DDTrace\Contracts\Scope;
 use DDTrace\GlobalTracer;
 use DDTrace\Tag;
+use DDTrace\Tracer;
 use DDTrace\Type;
 use function ddtrace_config_app_name;
 use function ddtrace_config_trace_enabled;
@@ -85,7 +86,13 @@ class DatadogProfiler implements ProfilerInterface
             return;
         }
 
-        GlobalTracer::get()->reset();
+        $this->scope = null;
+
+        // https://github.com/DataDog/dd-trace-php/issues/1533#issuecomment-1059211743
+        ini_set('datadog.trace.enabled', '0');
+        ini_set('datadog.trace.enabled', '1');
+
+        GlobalTracer::set(new Tracer());
     }
 
     private function isEnabled(): bool

--- a/src/Profiler/DatadogProfiler.php
+++ b/src/Profiler/DatadogProfiler.php
@@ -8,7 +8,6 @@ use function dd_trace_env_config;
 use DDTrace\Contracts\Scope;
 use DDTrace\GlobalTracer;
 use DDTrace\Tag;
-use DDTrace\Tracer;
 use DDTrace\Type;
 use function ddtrace_config_app_name;
 use function ddtrace_config_trace_enabled;
@@ -22,26 +21,14 @@ class DatadogProfiler implements ProfilerInterface
 
     private LoggerInterface $logger;
 
-    private float $sampleRate = 1.0;
-
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
-
-        $sampleRateString = getenv('DD_TRACE_SAMPLE_RATE');
-        if (is_numeric($sampleRateString)) {
-            $sampleRate = (float) $sampleRateString;
-            $this->sampleRate = $sampleRate;
-        }
     }
 
     public function start(string $name, ?string $kind = null): void
     {
         if (!$this->isEnabled()) {
-            return;
-        }
-
-        if ($this->rateLimited()) {
             return;
         }
 
@@ -98,14 +85,7 @@ class DatadogProfiler implements ProfilerInterface
             return;
         }
 
-        GlobalTracer::set(new Tracer());
-    }
-
-    private function rateLimited(): bool
-    {
-        $randomFloat = mt_rand() / mt_getrandmax(); // between 0 and 1
-
-        return $randomFloat > $this->sampleRate;
+        GlobalTracer::get()->reset();
     }
 
     private function isEnabled(): bool


### PR DESCRIPTION
The sample rate is sent to the Datadog agent and is used even when manual profiling like this project does so the sampling logic in the `DataDogProfiler` is causing the sampling rate to be applied twice.  

In addition the Global tracer isn't being reset properly in `stopAndIgnore` which creates a single trace even when multiple traces are subsequently started and stopped.

```
#[AsCommand('app:profiler-test')]
class ProfilerTestCommand extends Command
{
    public function __construct(private ProfilerInterface $profiler)
    {
        parent::__construct();
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        $this->profiler->stopAndIgnore();

        for ($i = 0; $i < 5; $i++) {
            $this->profiler->start('test');
            $output->writeln((string) $i);
            usleep(50000);
            $this->profiler->stop();
        }
        return Command::SUCCESS;
    }
}
```

There are no traces on master.  In the screenshot you can see 2 requests since I ran the command twice, but no spans were created.
<img width="662" alt="Screenshot 2024-01-11 at 7 47 42 AM" src="https://github.com/sourceability/instrumentation/assets/32892822/baa7269e-00b1-494b-bebd-7f9437ae922c">

There are 4 traces using this branch:
<img width="1501" alt="Screenshot 2024-01-11 at 7 31 49 AM" src="https://github.com/sourceability/instrumentation/assets/32892822/a864febe-2bc4-4912-a619-ef095841ec72">




