### PR TITLE
Add Symfony 7.0 compatibility

### DIFF
--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sourceability_instrumentation');
         $rootNode = $treeBuilder->getRootNode();


### PR DESCRIPTION
This seems to be the only change needed to let it run under Symfony 7.0

```
Declaration of Sourceability\Instrumentation\Bundle\DependencyInjection\Configuration::getConfigTreeBuilder() must be compatible with Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder(): Symfony\Component\Config\Definition\Builder\TreeBuilder
```

I assume Symfony 7.0 needs to be added to the suggestions in the composer.json as well. Do you need it somewhere else as well? Maybe for testing?