### PR TITLE
Fix exception thrown using the Symfony profiler for Messenger workers #24

### DIFF
--- a/src/EventListener/MessengerProfilerListener.php
+++ b/src/EventListener/MessengerProfilerListener.php
@@ -34,7 +34,7 @@ class MessengerProfilerListener implements EventSubscriberInterface
 
     public function onInvoke(WorkerMessageReceivedEvent $event): void
     {
-        $transactionName = \get_class($event->getEnvelope()->getMessage());
+        $transactionName = str_replace('\\', '/', \get_class($event->getEnvelope()->getMessage()));
 
         $this->profiler->stop();
         $this->profiler->start($transactionName, 'messenger');

--- a/src/Messenger/ProfilerMiddleware.php
+++ b/src/Messenger/ProfilerMiddleware.php
@@ -29,7 +29,7 @@ class ProfilerMiddleware implements MiddlewareInterface
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        $transactionName = \get_class($envelope->getMessage());
+        $transactionName = str_replace('\\', '/', \get_class($envelope->getMessage()));
 
         $skip = false;
         if (null !== $this->requestStack

--- a/src/Profiler/SymfonyProfiler.php
+++ b/src/Profiler/SymfonyProfiler.php
@@ -45,6 +45,7 @@ class SymfonyProfiler implements ProfilerInterface
             $kind = 'custom';
         }
 
+        $name = str_replace('\\', '/', $name);
         $uri = sprintf('http://%s/%s', $kind, $name);
 
         $this->request = Request::create($uri, $kind);


### PR DESCRIPTION
Fixes #24

Fix exception thrown using the Symfony profiler for Messenger workers

* Replace backslashes with regular slashes in the transaction name in `src/EventListener/MessengerProfilerListener.php`
  * Use `str_replace('\\', '/', \get_class($event->getEnvelope()->getMessage()))`
* Replace backslashes with regular slashes in the transaction name in `src/Messenger/ProfilerMiddleware.php`
  * Use `str_replace('\\', '/', \get_class($envelope->getMessage()))`
* Ensure the transaction name is used in the URI with regular slashes in `src/Profiler/SymfonyProfiler.php`
  * Replace backslashes with regular slashes in the URI

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sourceability/instrumentation/pull/25?shareId=dba6ab2b-9717-41df-93b1-806d7362c429).